### PR TITLE
Correct generation of text-anchor in mapbox style

### DIFF
--- a/src/ocad-to-mapbox-gl-style.js
+++ b/src/ocad-to-mapbox-gl-style.js
@@ -281,7 +281,7 @@ const textLayer = (id, source, sourceLayer, scaleFactor, filter, element, colors
       'text-ignore-placement': true,
       'text-max-width': Infinity,
       'text-justify': justify,
-      'text-anchor': `${anchor}${anchor !== 'center' ? `-${justify}` : ''}`,
+      'text-anchor': `${anchor}${justify !== 'center' ? `-${justify}` : ''}`,
       'text-pitch-alignment': 'map',
       'text-rotation-alignment': 'map'
     },


### PR DESCRIPTION
For the text-anchor is the justification is "center" is should be
omitted from the text-anchor name. For example, "top" is correct rather
than "top-center"

See: https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-density

Fixes #1