### PR TITLE
Install arr-flatten as dependency (used by ocad-to-geojson and ocad-to-svg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,8 +582,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-find-index": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@turf/bbox": "^6.0.1",
     "@turf/meta": "^6.0.2",
+    "arr-flatten": "^1.1.0",
     "bezier-js": "^2.4.0",
     "geojson-vt": "^3.2.0",
     "minimist": "^1.2.5",


### PR DESCRIPTION
Without this dependency package works only in development environment, because another devDependencies install it.

Running `NODE_ENV=production npm install && node cli.js` without this dependency fails with error.