### PR TITLE
Add shebang line to ocad-tool executable

### DIFF
--- a/src/ocad-tool.js
+++ b/src/ocad-tool.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require('fs')
 const http = require('http')
 const mkdirp = require('mkdirp')


### PR DESCRIPTION
When running ocad-tool from the command-line, ocad-tool.js would open in my text editor for editing, not executing the script. Adding the shebang line to point to the Node executable for the ocad-tool.js to execute. Tested to work locally on Windows after running npm install in to ocad2geojson root.