### PR TITLE
Double line fix

### DIFF
--- a/src/ocad-to-svg.js
+++ b/src/ocad-to-svg.js
@@ -313,7 +313,6 @@ const objectToSvg = (options, symbols, object) => {
       const dblMode = dbl?.dblMode ?? 0
       const hasFill = (dbl?.dblFlags ?? 0) & DblFillColorOn
 
-      //Detta känns inte korrekt???? Jag är ruskigt osäker hur denna ska vara
       const totalFillWidth =
         (dbl?.dblLeftWidth ?? 0) + (dbl?.dblWidth ?? 0) + (dbl?.dblRightWidth ?? 0)
     
@@ -343,6 +342,47 @@ const objectToSvg = (options, symbols, object) => {
           )
         )
       }
+      
+      if (dbl.dblLeftWidth > 0 && dbl.dblRightWidth > 0 && dbl.dblFlags & DblFillColorOn) {
+            node.children = node.children.concat([
+              lineToPath(
+                object.coordinates,
+                dbl.dblLeftWidth + dbl.dblRightWidth + dbl.dblWidth,
+                options.colors[dbl.dblLeftColor],
+                dashPattern,
+                symbol.lineStyle,
+                options.closePath
+              ),
+              lineToPath(
+                object.coordinates,
+                dbl.dblWidth,
+                options.colors[dbl.dblFillColor],
+                dashPattern,
+                symbol.lineStyle,
+                options.closePath
+              ),
+            ])
+          }
+
+      else if (dblMode === 1 && !(dbl?.dblFlags & DblFillColorOn)) {
+          node.children = node.children.concat(
+          [
+            -dbl.dblWidth/2 - dbl.dblLeftWidth / 2,
+            dbl.dblWidth/2 + dbl.dblRightWidth / 2,
+          ].map((offset, i) =>
+            lineToPath(
+              offsetLineCoordinates(object.coordinates, offset),
+              i === 0 ? dbl.dblLeftWidth : dbl.dblRightWidth,
+              options.colors[
+                i === 0 ? dbl.dblLeftColor : dbl.dblRightColor
+              ],
+              dashPattern,
+              symbol.lineStyle,
+              options.closePath
+            )
+          )
+        )
+      }  
     
       if (symbol.lineWidth > 0) {
         node.children.push(
@@ -356,6 +396,8 @@ const objectToSvg = (options, symbols, object) => {
           )
         )
       }
+
+      
     
       node.children = node.children.filter(Boolean)
       if (node.children.length === 0) {


### PR DESCRIPTION
I discovered that some double lines didn’t render correctly. In some cases lines were missing altogether.
One issue occurred when unfilled doublelines were rendered too far from the center (because dbl.dblWidth wasn’t divided by two).
The other issue happened when a line was set to “full line" mode but shouldn’t have been???. In that case, the line failed to render.

Some changes aren’t necessary, and I hope I didn’t miss or delete anything essential from the function.